### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete multi-character sanitization

### DIFF
--- a/pod-mac-vite/pod/src/utils/validators.ts
+++ b/pod-mac-vite/pod/src/utils/validators.ts
@@ -36,5 +36,18 @@ export const validateMailForm = (data: Partial<MailComposerData>): {
 };
 
 export const sanitizeInput = (input: string): string => {
-  return input.trim().replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
+  let sanitized = input.trim();
+
+  // Repeatedly remove <script>...</script> blocks to avoid multi-character sanitization issues
+  let previous: string;
+  const scriptBlockRegex = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi;
+  do {
+    previous = sanitized;
+    sanitized = sanitized.replace(scriptBlockRegex, '');
+  } while (sanitized !== previous);
+
+  // As a safety net, remove any remaining script tag openings/closings (even if malformed)
+  sanitized = sanitized.replace(/<\s*script\b/gi, '').replace(/<\/\s*script\s*>/gi, '');
+
+  return sanitized;
 };


### PR DESCRIPTION
Potential fix for [https://github.com/guptaji9630/podfolio/security/code-scanning/2](https://github.com/guptaji9630/podfolio/security/code-scanning/2)

In general, the safest fix is to avoid custom regex‑based HTML/script sanitization and instead use a well‑maintained library that repeatedly and correctly strips unsafe constructs. For script removal, libraries such as DOMPurify or sanitize-html are designed to handle many edge cases that hand‑rolled regexes miss.

Within this file, the best targeted fix that preserves existing functionality (removing `<script>...</script>` blocks while leaving other content alone) is to (a) avoid relying on a single multi‑character regex pass, and (b) ensure that any residual `<script`/`</script>` sequences are removed even if they appear in tricky forms. One straightforward approach is:
- First, repeatedly strip full `<script ...>...</script>` blocks in a loop until no more removals occur (addressing the “reappearing pattern” issue).
- Then, as a safety net, strip any remaining occurrences of `<script` and `</script>` (case‑insensitive), so that no script tag opener/closer can survive, even if malformed or incomplete.

This keeps the same basic intent (remove scripts, keep surrounding HTML) but closes the multi‑character sanitization gap without changing other validators. Concretely, in `pod-mac-vite/pod/src/utils/validators.ts`, we will replace the single `.replace(/<script...<\/script>/gi, '')` call in `sanitizeInput` with a small loop that repeatedly applies the regex and then removes any leftover `<script` / `</script>` substrings. No new imports are strictly required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
